### PR TITLE
refactor: rename a ViewUserState class

### DIFF
--- a/lib/view_user/bloc/view_user_bloc.dart
+++ b/lib/view_user/bloc/view_user_bloc.dart
@@ -7,9 +7,9 @@ import 'package:users_api/users_api.dart';
 part 'view_user_event.dart';
 part 'view_user_state.dart';
 
-class ViewUserBloc extends Bloc<ViewUserEvent, UserState> {
+class ViewUserBloc extends Bloc<ViewUserEvent, ViewUserState> {
   ViewUserBloc()
-      : super(const UserState(status: UserActivationStatus.loading)) {
+      : super(const ViewUserState(status: UserActivationStatus.loading)) {
     on<ActivateUser>(_onActivateUser);
     on<LockUser>(_onLockUser);
     on<GetUserFromDB>(_onGetUserFromDB);
@@ -18,7 +18,7 @@ class ViewUserBloc extends Bloc<ViewUserEvent, UserState> {
   }
 
   Future<void> _onGetUserFromMemory(
-      GetUserFromMemory event, Emitter<UserState> emit) async {
+      GetUserFromMemory event, Emitter<ViewUserState> emit) async {
     emit(state.copyWith(status: UserActivationStatus.loading));
     try {
       UserActivationStatus status;
@@ -34,7 +34,7 @@ class ViewUserBloc extends Bloc<ViewUserEvent, UserState> {
   }
 
   Future<void> _onGetUserFromDB(
-      GetUserFromDB event, Emitter<UserState> emit) async {
+      GetUserFromDB event, Emitter<ViewUserState> emit) async {
     emit(state.copyWith(status: UserActivationStatus.loading));
     try {
       final UsersApiClient _usersApi = UsersApiClient();
@@ -54,7 +54,7 @@ class ViewUserBloc extends Bloc<ViewUserEvent, UserState> {
   }
 
   Future<void> _onActivateUser(
-      ActivateUser event, Emitter<UserState> emit) async {
+      ActivateUser event, Emitter<ViewUserState> emit) async {
     emit(state.copyWith(status: UserActivationStatus.loading));
     try {
       final UsersApiClient _usersApi = UsersApiClient();
@@ -69,7 +69,7 @@ class ViewUserBloc extends Bloc<ViewUserEvent, UserState> {
     }
   }
 
-  Future<void> _onLockUser(LockUser event, Emitter<UserState> emit) async {
+  Future<void> _onLockUser(LockUser event, Emitter<ViewUserState> emit) async {
     emit(state.copyWith(status: UserActivationStatus.loading));
     try {
       final UsersApiClient _usersApi = UsersApiClient();
@@ -84,7 +84,8 @@ class ViewUserBloc extends Bloc<ViewUserEvent, UserState> {
     }
   }
 
-  Future<void> _onDeleteUser(DeleteUser event, Emitter<UserState> emit) async {
+  Future<void> _onDeleteUser(
+      DeleteUser event, Emitter<ViewUserState> emit) async {
     emit(state.copyWith(status: UserActivationStatus.loading));
     try {
       final UsersApiClient _usersApi = UsersApiClient();

--- a/lib/view_user/bloc/view_user_state.dart
+++ b/lib/view_user/bloc/view_user_state.dart
@@ -8,10 +8,10 @@ enum UserActivationStatus {
   deleted,
 }
 
-class UserState extends Equatable {
+class ViewUserState extends Equatable {
   final UserActivationStatus status;
   final User user;
-  const UserState({
+  const ViewUserState({
     this.status = UserActivationStatus.loading,
     this.user = const User(),
   });
@@ -19,11 +19,11 @@ class UserState extends Equatable {
   @override
   List<Object> get props => [status, user];
 
-  UserState copyWith({
+  ViewUserState copyWith({
     User? user,
     UserActivationStatus? status,
   }) {
-    return UserState(
+    return ViewUserState(
       user: user ?? this.user,
       status: status ?? this.status,
     );

--- a/lib/view_user/widgets/user_activate_button.dart
+++ b/lib/view_user/widgets/user_activate_button.dart
@@ -9,7 +9,7 @@ class UserActivationButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ViewUserBloc, UserState>(
+    return BlocBuilder<ViewUserBloc, ViewUserState>(
       builder: (context, state) {
         if (state.status == UserActivationStatus.locked) {
           return SizedBox(

--- a/lib/view_user/widgets/user_properties.dart
+++ b/lib/view_user/widgets/user_properties.dart
@@ -8,7 +8,7 @@ class UserPropertiesWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<ViewUserBloc, UserState>(
+    return BlocBuilder<ViewUserBloc, ViewUserState>(
       builder: (context, state) {
         return Row(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/test/view_user/bloc/view_user_bloc_test.dart
+++ b/test/view_user/bloc/view_user_bloc_test.dart
@@ -18,7 +18,7 @@ void main() {
     test('initial state', () {
       expect(
         viewUserBloc.state,
-        const UserState(
+        const ViewUserState(
           status: UserActivationStatus.loading,
           user: User(),
         ),
@@ -36,12 +36,12 @@ void main() {
     tearDown(() {
       viewUserBloc.close();
     });
-    blocTest<ViewUserBloc, UserState>(
+    blocTest<ViewUserBloc, ViewUserState>(
       'Loading first',
       build: () => viewUserBloc,
       act: (bloc) => bloc.add(ActivateUser()),
       expect: () => [
-        const UserState(
+        const ViewUserState(
           status: UserActivationStatus.loading,
           user: User(),
         ),

--- a/test/view_user/bloc/view_user_state_test.dart
+++ b/test/view_user/bloc/view_user_state_test.dart
@@ -4,11 +4,11 @@ import 'package:users_repository/users_repository.dart';
 
 void main() {
   group('UserState', () {
-    UserState createSubject({
+    ViewUserState createSubject({
       UserActivationStatus status = UserActivationStatus.loading,
       User user = const User(),
     }) {
-      return UserState(
+      return ViewUserState(
         status: status,
         user: user,
       );


### PR DESCRIPTION
In this PR we change the ViewUserState class name to make it different that UserState 