### PR TITLE
refactor: refactor bloc to take usersRepository as a property

### DIFF
--- a/lib/edit_user/bloc/edit_user_bloc.dart
+++ b/lib/edit_user/bloc/edit_user_bloc.dart
@@ -2,13 +2,12 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'dart:async';
 import 'package:users_repository/users_repository.dart';
-import 'package:users_api/users_api.dart';
 
 part 'edit_user_event.dart';
 part 'edit_user_state.dart';
 
 class EditUserBloc extends Bloc<EditUserEvent, UserState> {
-  EditUserBloc()
+  EditUserBloc({required this.usersRepository})
       : super(const UserState(status: EditUserStatus.loading, user: User())) {
     on<SetUserByID>(_onSetUserByID);
     on<NameEditing>(_onNameEditing);
@@ -16,14 +15,13 @@ class EditUserBloc extends Bloc<EditUserEvent, UserState> {
     on<SaveUser>(_onSaveUser);
   }
 
+  final UsersRepository usersRepository;
+
   Future<void> _onSetUserByID(
       SetUserByID event, Emitter<UserState> emit) async {
     emit(state.copyWith(status: EditUserStatus.loading));
     try {
-      final UsersApiClient _usersApi = UsersApiClient();
-      final UsersRepository _userRepository =
-          UsersRepository(usersApiClient: _usersApi);
-      final user = await _userRepository.getUser(event.id);
+      final user = await usersRepository.getUser(event.id);
       emit(state.copyWith(user: user, status: EditUserStatus.edit));
     } catch (_) {
       emit(state.copyWith(status: EditUserStatus.failure));
@@ -41,10 +39,7 @@ class EditUserBloc extends Bloc<EditUserEvent, UserState> {
   Future<void> _onSaveUser(SaveUser event, Emitter<UserState> emit) async {
     emit(state.copyWith(status: EditUserStatus.posting));
     try {
-      final UsersApiClient _usersApi = UsersApiClient();
-      final UsersRepository _userRepository =
-          UsersRepository(usersApiClient: _usersApi);
-      await _userRepository.updateUser(state.user);
+      await usersRepository.updateUser(state.user);
     } catch (_) {
       emit(state.copyWith(status: EditUserStatus.failure));
     }

--- a/lib/edit_user/view/edit_page.dart
+++ b/lib/edit_user/view/edit_page.dart
@@ -2,10 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:user_list/edit_user/bloc/edit_user_bloc.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:user_list/edit_user/widgets/edit_user_widget.dart';
+import 'package:users_repository/users_repository.dart';
 
 class EditPage extends StatelessWidget {
   final int id;
-  const EditPage({Key? key, required this.id}) : super(key: key);
+  const EditPage({
+    Key? key,
+    required this.id,
+  }) : super(key: key);
 
   static Route<void> route(int id) {
     return MaterialPageRoute(
@@ -16,7 +20,9 @@ class EditPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => EditUserBloc()..add(SetUserByID(id)),
+      create: (context) => EditUserBloc(
+        usersRepository: RepositoryProvider.of<UsersRepository>(context),
+      )..add(SetUserByID(id)),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Edit User'),

--- a/lib/new_user/cubit/new_user_cubit.dart
+++ b/lib/new_user/cubit/new_user_cubit.dart
@@ -2,25 +2,23 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'dart:async';
 import 'package:users_repository/users_repository.dart';
-import 'package:users_api/users_api.dart';
 
 part 'new_user_state.dart';
 
 class NewUserCubit extends Cubit<NewUserState> {
-  NewUserCubit()
+  NewUserCubit({required this.usersRepository})
       : super(const NewUserState(
           status: NewUserStatus.initial,
           firstname: '',
           lastname: '',
         ));
 
+  final UsersRepository usersRepository;
+
   Future<void> createNewUser(String firstname, String lastname) async {
     emit(state.copyWith(status: NewUserStatus.posting));
     try {
-      final UsersApiClient _usersApi = UsersApiClient();
-      final UsersRepository _userRepository =
-          UsersRepository(usersApiClient: _usersApi);
-      await _userRepository.createAndPostNewUser(
+      await usersRepository.createAndPostNewUser(
         firstname,
         lastname,
       );

--- a/lib/new_user/view/new_user_page.dart
+++ b/lib/new_user/view/new_user_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:user_list/new_user/widgets/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:user_list/new_user/cubit/new_user_cubit.dart';
+import 'package:users_repository/users_repository.dart';
 
 class NewUserPage extends StatelessWidget {
   const NewUserPage({Key? key}) : super(key: key);
@@ -15,7 +16,9 @@ class NewUserPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => NewUserCubit(),
+      create: (context) => NewUserCubit(
+        usersRepository: RepositoryProvider.of<UsersRepository>(context),
+      ),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Create a new user'),

--- a/lib/user_list/bloc/users_bloc.dart
+++ b/lib/user_list/bloc/users_bloc.dart
@@ -2,26 +2,25 @@ import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'dart:async';
 import 'package:users_repository/users_repository.dart';
-import 'package:users_api/users_api.dart';
 
 part 'users_event.dart';
 part 'users_state.dart';
 
 class UsersBloc extends Bloc<UsersEvent, UsersState> {
-  UsersBloc() : super(const UsersState()) {
+  UsersBloc({required this.usersRepository}) : super(const UsersState()) {
     on<UpdateUsersList>(_onUpdateUsersList);
     on<ChangeSortingMethod>(_onChangeSortingMethod);
   }
+
+  final UsersRepository usersRepository;
 
   Future<void> _onUpdateUsersList(
       UpdateUsersList event, Emitter<UsersState> emit) async {
     emit(state.copyWith(status: UsersStatus.loading));
     try {
-      final _userApi = UsersApiClient();
-      final _usersListRepository = UsersRepository(usersApiClient: _userApi);
-      final List<User> users = await _usersListRepository.getUsersList();
+      final List<User> users = await usersRepository.getUsersList();
       final List<User> sortedUsers =
-          await _usersListRepository.sortList(users, state.sortingBy);
+          await usersRepository.sortList(users, state.sortingBy);
       return emit(state.copyWith(
         users: sortedUsers,
         status: UsersStatus.success,

--- a/lib/user_list/view/users_page.dart
+++ b/lib/user_list/view/users_page.dart
@@ -4,6 +4,7 @@ import 'package:user_list/new_user/new_user.dart';
 import 'package:user_list/sorting/view/view.dart';
 import 'package:user_list/user_list/widgets/users_list.dart';
 import 'package:user_list/user_list/bloc/users_bloc.dart';
+import 'package:users_repository/users_repository.dart';
 
 class UsersPage extends StatelessWidget {
   const UsersPage({Key? key}) : super(key: key);
@@ -17,7 +18,9 @@ class UsersPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => UsersBloc()..add(UpdateUsersList()),
+      create: (context) => UsersBloc(
+        usersRepository: RepositoryProvider.of<UsersRepository>(context),
+      )..add(UpdateUsersList()),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('Users List'),
@@ -35,7 +38,10 @@ class UsersPage extends StatelessWidget {
                       SettingsPage.route(),
                     )
                     .whenComplete(
-                        () => context.read<UsersBloc>().add(UpdateUsersList()));
+                      () => context.read<UsersBloc>().add(
+                            UpdateUsersList(),
+                          ),
+                    );
               },
             ),
             IconButton(
@@ -49,7 +55,10 @@ class UsersPage extends StatelessWidget {
                       NewUserPage.route(),
                     )
                     .whenComplete(
-                        () => context.read<UsersBloc>().add(UpdateUsersList()));
+                      () => context.read<UsersBloc>().add(
+                            UpdateUsersList(),
+                          ),
+                    );
               },
             ),
             IconButton(
@@ -58,7 +67,9 @@ class UsersPage extends StatelessWidget {
                 color: Colors.white,
               ),
               onPressed: () {
-                context.read<UsersBloc>().add(UpdateUsersList());
+                context.read<UsersBloc>().add(
+                      UpdateUsersList(),
+                    );
               },
             )
           ],

--- a/lib/view_user/view/view_user_page.dart
+++ b/lib/view_user/view/view_user_page.dart
@@ -17,7 +17,11 @@ class ViewUserPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => ViewUserBloc()..add(GetUserFromMemory(user)),
+      create: (context) => ViewUserBloc(
+        usersRepository: RepositoryProvider.of<UsersRepository>(
+          context,
+        ),
+      )..add(GetUserFromMemory(user)),
       child: Scaffold(
         appBar: AppBar(
           title: const Text('User Page'),


### PR DESCRIPTION
In this PR we:
- change EditUserBloc to take usersRepository as a property,
- change EditPage to pass a userRepository to EditUserBloc,
- change NewUserBloc to take usersRepository as a property,
- change NewUserPage to pass a userRepository to NewUserBloc,
- change UsersBloc to take usersRepository as a property,
- change UsersPage to pass a userRepository to UsersBloc,
- change ViewUsersBloc to take usersRepository as a property,
- change ViewUserPage to pass a userRepository to ViewUsersBloc,