### PR TITLE
refactor: use postUser method instead of createAndPosNewUser method, postUser takes firstname and lastname as an arguments

### DIFF
--- a/lib/new_user/bloc/new_user_bloc.dart
+++ b/lib/new_user/bloc/new_user_bloc.dart
@@ -26,7 +26,7 @@ class NewUserBloc extends Bloc<NewUserEvent, NewUserState> {
       state.copyWith(status: NewUserStatus.posting),
     );
     try {
-      await usersRepository.createAndPostNewUser(
+      await usersRepository.postUser(
         event.firstname,
         event.lastname,
       );

--- a/packages/users_repository/lib/src/users_repository.dart
+++ b/packages/users_repository/lib/src/users_repository.dart
@@ -18,16 +18,12 @@ class UsersRepository {
     return await usersApiClient.deleteUser(id);
   }
 
-  Future<void> postUser(User user) async {
-    await usersApiClient.postUser(user);
+  Future<void> postUser(String firstname, String lastname) async {
+    await usersApiClient.postUser(firstname, lastname);
   }
 
   Future<void> updateUser(User user) async {
     await usersApiClient.updateUser(user);
-  }
-
-  Future<void> createAndPostNewUser(String name, String lastname) async {
-    return await usersApiClient.createAndPostNewUser(name, lastname);
   }
 
   Future<List<User>> getUsersList() async {


### PR DESCRIPTION
In this PR we:
- use postUser method instead of createAndPosNewUser method,
- delete createAndPosNewUser method,
- change postUser method to receive firstname and lastname as an arguments