### PR TITLE
refactor(edit_user): rename EditUserState and add success status

### DIFF
--- a/lib/edit_user/bloc/edit_user_state.dart
+++ b/lib/edit_user/bloc/edit_user_state.dart
@@ -5,13 +5,14 @@ enum EditUserStatus {
   posting,
   loading,
   failure,
+  success,
 }
 
-class UserState extends Equatable {
+class EditUserState extends Equatable {
   final User user;
   final EditUserStatus status;
 
-  const UserState({
+  const EditUserState({
     required this.user,
     required this.status,
   });
@@ -19,11 +20,11 @@ class UserState extends Equatable {
   @override
   List<Object> get props => [user, status];
 
-  UserState copyWith({
+  EditUserState copyWith({
     User? user,
     EditUserStatus? status,
   }) {
-    return UserState(
+    return EditUserState(
       user: user ?? this.user,
       status: status ?? this.status,
     );

--- a/lib/edit_user/widgets/edit_user_widget.dart
+++ b/lib/edit_user/widgets/edit_user_widget.dart
@@ -8,7 +8,7 @@ class EditUserWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<EditUserBloc, UserState>(
+    return BlocBuilder<EditUserBloc, EditUserState>(
       builder: (context, state) {
         switch (state.status) {
           case EditUserStatus.failure:

--- a/lib/edit_user/widgets/user_properties_form.dart
+++ b/lib/edit_user/widgets/user_properties_form.dart
@@ -23,7 +23,7 @@ class _UserPropertiesFormState extends State<UserPropertiesForm> {
             child: Row(
               children: [
                 Expanded(
-                  child: BlocBuilder<EditUserBloc, UserState>(
+                  child: BlocBuilder<EditUserBloc, EditUserState>(
                     builder: (context, state) {
                       return TextFormField(
                         initialValue: state.user.firstname,
@@ -46,7 +46,7 @@ class _UserPropertiesFormState extends State<UserPropertiesForm> {
             child: Row(
               children: [
                 Expanded(
-                  child: BlocBuilder<EditUserBloc, UserState>(
+                  child: BlocBuilder<EditUserBloc, EditUserState>(
                     builder: (context, state) {
                       return TextFormField(
                         initialValue: state.user.lastname,


### PR DESCRIPTION
In this PR we:
- rename the EditUserState (previous name UserState),
- add another EditUserStatus (success), it's needed for presenting the SnackBar,