### PR TITLE
fix(users_api): fixing exception handling

### DIFF
--- a/packages/users_api/lib/src/users_api_client.dart
+++ b/packages/users_api/lib/src/users_api_client.dart
@@ -38,7 +38,7 @@ class UsersApiClient {
       '/users/${id.toString()}.json',
     );
     final response = await _httpClient.get(uri);
-    if (response.statusCode != 200) {
+    if (response.statusCode < 200 || response.statusCode > 299) {
       throw GetUserRequestFailure();
     }
     try {
@@ -55,7 +55,7 @@ class UsersApiClient {
       '/users/${id.toString()}.json',
     );
     final response = await _httpClient.delete(uri);
-    if (response.statusCode != 200) {
+    if (response.statusCode < 200 || response.statusCode > 299) {
       throw DeleteUserRequestFailure();
     }
   }
@@ -89,16 +89,14 @@ class UsersApiClient {
       authority,
       '/users/${id.toString()}.json',
     );
-
-    try {
-      await _httpClient.patch(
-        uri,
-        headers: <String, String>{
-          'Content-Type': 'application/json; charset=UTF-8',
-        },
-        body: jsonEncode(user),
-      );
-    } catch (_) {
+    final response = await _httpClient.patch(
+      uri,
+      headers: <String, String>{
+        'Content-Type': 'application/json; charset=UTF-8',
+      },
+      body: jsonEncode(user),
+    );
+    if (response.statusCode < 200 || response.statusCode > 299) {
       throw UpdateUserRequestFailure();
     }
   }

--- a/packages/users_api/test/src/users_api_client_test.dart
+++ b/packages/users_api/test/src/users_api_client_test.dart
@@ -157,7 +157,7 @@ void main() {
     group('deleteUser', () {
       test('makes correct http request', () async {
         final response = MockResponse();
-        when(() => response.statusCode).thenReturn(200);
+        when(() => response.statusCode).thenReturn(204);
         when(() => response.body).thenReturn('{}');
         when(
           () => httpClient.delete(
@@ -179,7 +179,7 @@ void main() {
 
       test('throws DeleteUserRequestFailure on non-200 response', () async {
         final response = MockResponse();
-        when(() => response.statusCode).thenReturn(400);
+        when(() => response.statusCode).thenReturn(422);
         when(
           () => httpClient.delete(
             any(),
@@ -272,6 +272,8 @@ void main() {
         when(
           () => httpClient.patch(
             any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'),
           ),
         ).thenAnswer((_) async => response);
         expect(


### PR DESCRIPTION
In this PR we:
- change the http method failure exception from try/catch to response.statusCode if statement,
- fix non-200 edit User response by adding needed patch arguments (headers and body) to editUser tests.