### PR TITLE
feat(edit_user)!: changes to provide snackbar

### DIFF
--- a/lib/edit_user/bloc/edit_user_bloc.dart
+++ b/lib/edit_user/bloc/edit_user_bloc.dart
@@ -6,9 +6,10 @@ import 'package:users_repository/users_repository.dart';
 part 'edit_user_event.dart';
 part 'edit_user_state.dart';
 
-class EditUserBloc extends Bloc<EditUserEvent, UserState> {
+class EditUserBloc extends Bloc<EditUserEvent, EditUserState> {
   EditUserBloc({required this.usersRepository})
-      : super(const UserState(status: EditUserStatus.loading, user: User())) {
+      : super(
+            const EditUserState(status: EditUserStatus.loading, user: User())) {
     on<SetUserByID>(_onSetUserByID);
     on<NameEditing>(_onNameEditing);
     on<LastnameEditing>(_onLastnameEditing);
@@ -18,28 +19,33 @@ class EditUserBloc extends Bloc<EditUserEvent, UserState> {
   final UsersRepository usersRepository;
 
   Future<void> _onSetUserByID(
-      SetUserByID event, Emitter<UserState> emit) async {
+      SetUserByID event, Emitter<EditUserState> emit) async {
     emit(state.copyWith(status: EditUserStatus.loading));
     try {
       final user = await usersRepository.getUser(event.id);
       emit(state.copyWith(user: user, status: EditUserStatus.edit));
     } catch (_) {
-      emit(state.copyWith(status: EditUserStatus.failure));
+      emit(state.copyWith(status: EditUserStatus.failureToGet));
     }
   }
 
-  void _onNameEditing(NameEditing event, Emitter<UserState> emit) {
+  void _onNameEditing(NameEditing event, Emitter<EditUserState> emit) {
     emit(state.copyWith(user: state.user.copyWith(firstname: event.firstname)));
   }
 
-  void _onLastnameEditing(LastnameEditing event, Emitter<UserState> emit) {
+  void _onLastnameEditing(LastnameEditing event, Emitter<EditUserState> emit) {
     emit(state.copyWith(user: state.user.copyWith(lastname: event.lastname)));
   }
 
-  Future<void> _onSaveUser(SaveUser event, Emitter<UserState> emit) async {
+  Future<void> _onSaveUser(SaveUser event, Emitter<EditUserState> emit) async {
     emit(state.copyWith(status: EditUserStatus.posting));
     try {
       await usersRepository.updateUser(state.user);
+      emit(
+        state.copyWith(
+          status: EditUserStatus.success,
+        ),
+      );
     } catch (_) {
       emit(state.copyWith(status: EditUserStatus.failure));
     }

--- a/lib/edit_user/bloc/edit_user_state.dart
+++ b/lib/edit_user/bloc/edit_user_state.dart
@@ -6,6 +6,7 @@ enum EditUserStatus {
   loading,
   failure,
   success,
+  failureToGet,
 }
 
 class EditUserState extends Equatable {

--- a/lib/edit_user/view/edit_page.dart
+++ b/lib/edit_user/view/edit_page.dart
@@ -22,7 +22,7 @@ class EditPage extends StatelessWidget {
       create: (context) => EditUserBloc(
         usersRepository: RepositoryProvider.of<UsersRepository>(context),
       )..add(SetUserByID(id)),
-      child: EditUserView(),
+      child: const EditUserView(),
     );
   }
 }
@@ -51,6 +51,17 @@ class EditUserView extends StatelessWidget {
             ..showSnackBar(
               const SnackBar(
                 content: Text('User has been edited successfully'),
+              ),
+            );
+        }
+
+        if (state.status == EditUserStatus.failureToGet) {
+          Navigator.pop(context);
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('Failed to get a User from Database'),
               ),
             );
         }

--- a/lib/edit_user/widgets/edit_user_widget.dart
+++ b/lib/edit_user/widgets/edit_user_widget.dart
@@ -11,9 +11,6 @@ class EditUserWidget extends StatelessWidget {
     return BlocBuilder<EditUserBloc, EditUserState>(
       builder: (context, state) {
         switch (state.status) {
-          case EditUserStatus.failure:
-            return const Center(child: Text('Failed to edit the User'));
-
           case EditUserStatus.edit:
             return Column(
               mainAxisAlignment: MainAxisAlignment.start,


### PR DESCRIPTION
In this PR we:
- rename EditUserState (previous name: UserState),
- add success and failureToGet as a new EditUsersStatus,
- remove separate case widget when status is failure,
- displays snackBar when fails to get the user,
- making sure that UI returns proper information for every possible application state!