### PR TITLE
feat(view_user): snackbars

### DIFF
--- a/lib/view_user/bloc/view_user_bloc.dart
+++ b/lib/view_user/bloc/view_user_bloc.dart
@@ -8,7 +8,9 @@ part 'view_user_state.dart';
 
 class ViewUserBloc extends Bloc<ViewUserEvent, ViewUserState> {
   ViewUserBloc({required this.usersRepository})
-      : super(const ViewUserState(status: UserActivationStatus.loading)) {
+      : super(
+          const ViewUserState(),
+        ) {
     on<ActivateUser>(_onActivateUser);
     on<LockUser>(_onLockUser);
     on<GetUserFromDB>(_onGetUserFromDB);
@@ -20,69 +22,112 @@ class ViewUserBloc extends Bloc<ViewUserEvent, ViewUserState> {
 
   Future<void> _onGetUserFromMemory(
       GetUserFromMemory event, Emitter<ViewUserState> emit) async {
-    emit(state.copyWith(status: UserActivationStatus.loading));
+    emit(
+      const ViewUserState(status: ViewUserStatus.loading),
+    );
     try {
-      UserActivationStatus status;
+      ViewUserStatus status;
       if (event.user.status == 'active') {
-        status = UserActivationStatus.active;
+        status = ViewUserStatus.active;
       } else {
-        status = UserActivationStatus.locked;
+        status = ViewUserStatus.locked;
       }
-      emit(state.copyWith(user: event.user, status: status));
+      emit(
+        state.copyWith(
+          user: event.user,
+          status: status,
+        ),
+      );
     } catch (_) {
-      emit(state.copyWith(status: UserActivationStatus.failure));
+      emit(
+        state.copyWith(message: ViewUserMessage.failureToGet),
+      );
     }
   }
 
   Future<void> _onGetUserFromDB(
       GetUserFromDB event, Emitter<ViewUserState> emit) async {
-    emit(state.copyWith(status: UserActivationStatus.loading));
+    emit(state.copyWith(status: ViewUserStatus.loading));
     try {
       final user = await usersRepository.getUser(state.user.id);
-      UserActivationStatus status;
+      ViewUserStatus status;
       if (user.status == 'active') {
-        status = UserActivationStatus.active;
+        status = ViewUserStatus.active;
       } else {
-        status = UserActivationStatus.locked;
+        status = ViewUserStatus.locked;
       }
-      emit(state.copyWith(user: user, status: status));
+      emit(
+        ViewUserState(
+          user: user,
+          status: status,
+        ),
+      );
     } catch (_) {
-      emit(state.copyWith(status: UserActivationStatus.failure));
+      emit(
+        state.copyWith(message: ViewUserMessage.failureToGet),
+      );
     }
   }
 
   Future<void> _onActivateUser(
       ActivateUser event, Emitter<ViewUserState> emit) async {
-    emit(state.copyWith(status: UserActivationStatus.loading));
     try {
       User user = state.user.copyWith(status: 'active');
       await usersRepository.updateUser(user);
-      emit(state.copyWith(status: UserActivationStatus.active, user: user));
+      emit(
+        state.copyWith(
+          status: ViewUserStatus.active,
+          user: user,
+          message: ViewUserMessage.activated,
+        ),
+      );
     } catch (_) {
-      emit(state.copyWith(status: UserActivationStatus.failure));
+      emit(
+        state.copyWith(message: ViewUserMessage.failureToActivate),
+      );
+      emit(
+        state.copyWith(message: ViewUserMessage.empty),
+      );
     }
   }
 
   Future<void> _onLockUser(LockUser event, Emitter<ViewUserState> emit) async {
-    emit(state.copyWith(status: UserActivationStatus.loading));
     try {
       User user = state.user.copyWith(status: 'locked');
       await usersRepository.updateUser(user);
-      emit(state.copyWith(status: UserActivationStatus.locked, user: user));
+      emit(
+        state.copyWith(
+          status: ViewUserStatus.locked,
+          user: user,
+          message: ViewUserMessage.locked,
+        ),
+      );
     } catch (_) {
-      emit(state.copyWith(status: UserActivationStatus.failure));
+      emit(
+        state.copyWith(message: ViewUserMessage.failureToLock),
+      );
+      emit(
+        state.copyWith(message: ViewUserMessage.empty),
+      );
     }
   }
 
   Future<void> _onDeleteUser(
       DeleteUser event, Emitter<ViewUserState> emit) async {
-    emit(state.copyWith(status: UserActivationStatus.loading));
+    emit(state.copyWith(status: ViewUserStatus.loading));
     try {
       await usersRepository.deleteUser(state.user.id);
-      emit(state.copyWith(
-          status: UserActivationStatus.deleted, user: const User()));
+      emit(
+        state.copyWith(
+          status: ViewUserStatus.deleted,
+          user: const User(),
+          message: ViewUserMessage.deleted,
+        ),
+      );
     } catch (_) {
-      emit(state.copyWith(status: UserActivationStatus.failure));
+      emit(
+        state.copyWith(message: ViewUserMessage.failureToDelete),
+      );
     }
   }
 }

--- a/lib/view_user/bloc/view_user_state.dart
+++ b/lib/view_user/bloc/view_user_state.dart
@@ -1,31 +1,45 @@
 part of 'view_user_bloc.dart';
 
-enum UserActivationStatus {
+enum ViewUserStatus {
   loading,
   active,
   locked,
-  failure,
+  deleted,
+}
+
+enum ViewUserMessage {
+  activated,
+  locked,
+  failureToActivate,
+  failureToLock,
+  failureToDelete,
+  failureToGet,
+  empty,
   deleted,
 }
 
 class ViewUserState extends Equatable {
-  final UserActivationStatus status;
-  final User user;
   const ViewUserState({
-    this.status = UserActivationStatus.loading,
+    this.status = ViewUserStatus.loading,
     this.user = const User(),
+    this.message = ViewUserMessage.empty,
   });
+  final ViewUserStatus status;
+  final User user;
+  final ViewUserMessage message;
 
   @override
-  List<Object> get props => [status, user];
+  List<Object> get props => [status, user, message];
 
   ViewUserState copyWith({
+    ViewUserStatus? status,
     User? user,
-    UserActivationStatus? status,
+    ViewUserMessage? message,
   }) {
     return ViewUserState(
-      user: user ?? this.user,
       status: status ?? this.status,
+      user: user ?? this.user,
+      message: message ?? this.message,
     );
   }
 }

--- a/lib/view_user/view/view_user_page.dart
+++ b/lib/view_user/view/view_user_page.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:users_repository/users_repository.dart';
-import 'package:user_list/view_user/widgets/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:user_list/view_user/bloc/view_user_bloc.dart';
+import 'package:user_list/view_user/view_user.dart';
 
 class ViewUserPage extends StatelessWidget {
   final User user;
@@ -21,10 +20,97 @@ class ViewUserPage extends StatelessWidget {
         usersRepository: RepositoryProvider.of<UsersRepository>(
           context,
         ),
-      )..add(GetUserFromMemory(user)),
+      )..add(
+          GetUserFromMemory(user),
+        ),
+      child: const ViewUserView(),
+    );
+  }
+}
+
+class ViewUserView extends StatelessWidget {
+  const ViewUserView({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ViewUserBloc, ViewUserState>(
+      listenWhen: (previous, current) => previous.message != current.message,
+      listener: (context, state) {
+        if (state.message == ViewUserMessage.failureToGet) {
+          Navigator.pop(context);
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('Failed to get the User'),
+              ),
+            );
+        }
+
+        if (state.message == ViewUserMessage.deleted) {
+          Navigator.pop(context);
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('User deleted'),
+              ),
+            );
+        }
+
+        if (state.message == ViewUserMessage.failureToDelete) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('Failed to delete the User'),
+              ),
+            );
+        }
+
+        if (state.message == ViewUserMessage.activated) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('User has been activated'),
+              ),
+            );
+        }
+
+        if (state.message == ViewUserMessage.failureToActivate) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('Failed to activate the User'),
+              ),
+            );
+        }
+
+        if (state.message == ViewUserMessage.locked) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('User has been locked'),
+              ),
+            );
+        }
+
+        if (state.message == ViewUserMessage.failureToLock) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(
+              const SnackBar(
+                content: Text('Failed to lock the User'),
+              ),
+            );
+        }
+      },
       child: Scaffold(
         appBar: AppBar(
-          title: const Text('User Page'),
+          title: const Text('View User'),
         ),
         body: const Center(
           child: ViewUserWidget(),

--- a/lib/view_user/widgets/user_activate_button.dart
+++ b/lib/view_user/widgets/user_activate_button.dart
@@ -11,7 +11,7 @@ class UserActivationButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<ViewUserBloc, ViewUserState>(
       builder: (context, state) {
-        if (state.status == UserActivationStatus.locked) {
+        if (state.status == ViewUserStatus.locked) {
           return SizedBox(
             width: 200,
             child: ElevatedButton(

--- a/lib/view_user/widgets/view_user_widget.dart
+++ b/lib/view_user/widgets/view_user_widget.dart
@@ -11,10 +11,7 @@ class ViewUserWidget extends StatelessWidget {
     return BlocBuilder<ViewUserBloc, ViewUserState>(
       builder: (context, state) {
         switch (state.status) {
-          case UserActivationStatus.failure:
-            return const Center(child: Text('Failed to get/post the User'));
-
-          case UserActivationStatus.loading:
+          case ViewUserStatus.loading:
             return Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: const [
@@ -24,9 +21,8 @@ class ViewUserWidget extends StatelessWidget {
               ],
             );
 
-          case UserActivationStatus.deleted:
-            return const Center(
-                child: Text('User has been successfully deleted'));
+          case ViewUserStatus.deleted:
+            return const Scaffold();
 
           default:
             return Column(


### PR DESCRIPTION
In this PR we:
- rename ViewUserStatus,
- add ViewUserMessage as a ViewUserState property,
- emit state with a ViewUserMessage property,
- create ViewUserView widget which contains BlocListener,
- displays the SnackBars when ViewUserMessage changes,
- remove case widget when status is failure,
- now SnackBars are responsible for providing informations.